### PR TITLE
Rename corner-radius to border-radius & Implement Skia border-radius.

### DIFF
--- a/Source/Demos/HtmlRenderer.Demo.Common/DemoUtils.cs
+++ b/Source/Demos/HtmlRenderer.Demo.Common/DemoUtils.cs
@@ -74,8 +74,8 @@ namespace TheArtOfDev.HtmlRenderer.Demo.Common
                     a:link { text-decoration: none; }
                     a:hover { text-decoration: underline; }
                     .gray    { color:gray; }
-                    .example { background-color:#efefef; corner-radius:5px; padding:0.5em; }
-                    .whitehole { background-color:white; corner-radius:10px; padding:15px; }
+                    .example { background-color:#efefef; border-radius:5px; padding:0.5em; }
+                    .whitehole { background-color:white; border-radius:10px; padding:15px; }
                     .caption { font-size: 1.1em }
                     .comment { color: green; margin-bottom: 5px; margin-left: 3px; }
                     .comment2 { color: green; }";

--- a/Source/Demos/HtmlRenderer.Demo.Common/Samples/07.Additional features.htm
+++ b/Source/Demos/HtmlRenderer.Demo.Common/Samples/07.Additional features.htm
@@ -27,16 +27,16 @@
                 vertical-align: middle;
             }
 
-            .c1 { corner-radius: 0px; }
+            .c1 { border-radius: 0px; }
 
-            .c2 { corner-radius: 10px; }
+            .c2 { border-radius: 10px; }
 
-            .c3 { corner-radius: 0px 10px 10px 0px; }
+            .c3 { border-radius: 0px 10px 10px 0px; }
 
-            .c4 { corner-radius: 18px; }
+            .c4 { border-radius: 18px; }
 
             .c5 {
-                corner-radius: 10px;
+                border-radius: 10px;
                 border: outset #BBBB00 2px;
             }
 
@@ -121,15 +121,15 @@
             <p>
                 In this renderer, the rounded corners are achieved by adding this CSS properties:</p>
             <ul>
-                <li><code>corner-ne-radius: (length)</code> Indicates the radius of the north-east corner.
+                <li><code>border-top-right-radius: (length)</code> Indicates the radius of the top-right corner.
                     Not ineritted</li>
-                <li><code>corner-se-radius: (length)</code> Indicates the radius of the south-east corner.
+                <li><code>border-bottom-right-radius: (length)</code> Indicates the radius of the bottom-right corner.
                     Not ineritted</li>
-                <li><code>corner-sw-radius: (length)</code> Indicates the radius of the south-west corner.
+                <li><code>border-bottom-left-radius: (length)</code> Indicates the radius of the bottom-left corner.
                     Not ineritted</li>
-                <li><code>corner-nw-radius: (length)</code> Indicates the radius of the north-west corner.
+                <li><code>border-top-left-radius: (length)</code> Indicates the radius of the top-left corner.
                     Not ineritted</li>
-                <li><code>corner-radius: (length){1,4}</code> Shorthand for the other corner properties.
+                <li><code>border-radius: (length){1,4}</code> Shorthand for the other corner properties.
                     Not ineritted</li>
             </ul>
             <!-- Corners table -->
@@ -160,11 +160,11 @@
                 </tr>
             </table>
             <pre>.c1, .c2, .c3, .c4, .c5 { background-color:olive; border:0px; color:white; vertical-align:middle; }
-.c1  { corner-radius: 0px }
-.c2  { corner-radius: 10px }
-.c3  { corner-radius: 0px 10px 10px 0px }
-.c4  { corner-radius: 18px }
-.c5  { corner-radius: 10px; border: outset #bb0 2px; }</pre>
+.c1  { border-radius: 0px }
+.c2  { border-radius: 10px }
+.c3  { border-radius: 0px 10px 10px 0px }
+.c4  { border-radius: 18px }
+.c5  { border-radius: 10px; border: outset #bb0 2px; }</pre>
         </blockquote>
     </body>
 </html>

--- a/Source/Demos/HtmlRenderer.Demo.Common/TestSamples/16.Borders.htm
+++ b/Source/Demos/HtmlRenderer.Demo.Common/TestSamples/16.Borders.htm
@@ -12,13 +12,13 @@
                 </div>
             </p>
             <p>
-                <div style="padding: 5px; border: 1px solid black; corner-radius: 5px;">
-                    border 1px with corner-radius 5px
+                <div style="padding: 5px; border: 1px solid black; border-radius: 5px;">
+                    border 1px with border-radius 5px
                 </div>
             </p>
             <p>
-                <div style="padding: 5px; border: 2px solid black; corner-radius: 10px;">
-                    border 2px with corner-radius 10px
+                <div style="padding: 5px; border: 2px solid black; border-radius: 10px;">
+                    border 2px with border-radius 10px
                 </div>
             </p>
             <p>
@@ -37,8 +37,8 @@
                 </div>
             </p>
             <p>
-                <div style="padding: 5px; border: 2px dashed darkred; corner-radius: 10px;">
-                    dashed border 2px with corner-radius 10px
+                <div style="padding: 5px; border: 2px dashed darkred; border-radius: 10px;">
+                    dashed border 2px with border-radius 10px
                 </div>
             </p>
         </div>

--- a/Source/Demos/HtmlRenderer.Demo.Console/Program.cs
+++ b/Source/Demos/HtmlRenderer.Demo.Console/Program.cs
@@ -11,7 +11,7 @@ if (args.Length > 0)
 }
 
 //Probably won't be running a suite of tests more than once a second, so this will do.
-string runIdentifier = DateTime.Now.ToString("ddMMyyyy-hhmmss");
+string runIdentifier = DateTime.Now.ToString("yyyyMMdd-hhmmss");
 
 var skia = new SkiaConverter(runIdentifier, basePath);
 var pdfSharp = new PdfSharpCoreConverter(runIdentifier, basePath);

--- a/Source/HtmlRenderer.SkiaSharp/Adapters/GraphicsAdapter.cs
+++ b/Source/HtmlRenderer.SkiaSharp/Adapters/GraphicsAdapter.cs
@@ -20,7 +20,7 @@ using TheArtOfDev.HtmlRenderer.SkiaSharp.Utilities;
 namespace TheArtOfDev.HtmlRenderer.SkiaSharp.Adapters
 {
     /// <summary>
-    /// Adapter for WinForms Graphics for core.
+    /// Adapter for Skia Graphics for core.
     /// </summary>
     internal sealed class GraphicsAdapter : RGraphics
     {

--- a/Source/HtmlRenderer.SkiaSharp/Adapters/GraphicsPathAdapter.cs
+++ b/Source/HtmlRenderer.SkiaSharp/Adapters/GraphicsPathAdapter.cs
@@ -19,14 +19,14 @@ using TheArtOfDev.HtmlRenderer.Adapters.Entities;
 namespace TheArtOfDev.HtmlRenderer.SkiaSharp.Adapters
 {
     /// <summary>
-    /// Adapter for WinForms graphics path object for core.
+    /// Adapter for Skia graphics path object for core.
     /// </summary>
     internal sealed class GraphicsPathAdapter : RGraphicsPath
     {
         /// <summary>
-        /// The actual PdfSharp graphics path instance.
+        /// The actual SKPath graphics path instance.
         /// </summary>
-        private readonly SKPath _graphicsPath = new SKPath();
+        private readonly SKPath _graphicsPath = new();
 
         /// <summary>
         /// the last point added to the path to begin next segment from
@@ -34,7 +34,7 @@ namespace TheArtOfDev.HtmlRenderer.SkiaSharp.Adapters
         private RPoint _lastPoint;
 
         /// <summary>
-        /// The actual PdfSharp graphics path instance.
+        /// The actual SKPath graphics path instance.
         /// </summary>
         public SKPath GraphicsPath
         {
@@ -44,6 +44,7 @@ namespace TheArtOfDev.HtmlRenderer.SkiaSharp.Adapters
         public override void Start(double x, double y)
         {
             _lastPoint = new RPoint(x, y);
+            _graphicsPath.MoveTo((float)x, (float)y);
         }
 
         public override void LineTo(double x, double y)
@@ -56,12 +57,16 @@ namespace TheArtOfDev.HtmlRenderer.SkiaSharp.Adapters
         {
             float left = (float)(Math.Min(x, _lastPoint.X) - (corner == Corner.TopRight || corner == Corner.BottomRight ? size : 0));
             float top = (float)(Math.Min(y, _lastPoint.Y) - (corner == Corner.BottomLeft || corner == Corner.BottomRight ? size : 0));
-            _graphicsPath.ArcTo(left, top, (float)size * 2, (float)size * 2, GetStartAngle(corner));
+
+            var rect = SKRect.Create(left, top, (float)size * 2, (float)size * 2);
+            _graphicsPath.ArcTo(rect, GetStartAngle(corner), 90f, false);
             _lastPoint = new RPoint(x, y);
         }
 
         public override void Dispose()
-        { }
+        {
+            _graphicsPath.Dispose();
+        }
 
         /// <summary>
         /// Get arc start angle for the given corner.

--- a/Source/HtmlRenderer.SkiaSharp/Adapters/SkiaSharpAdapter.cs
+++ b/Source/HtmlRenderer.SkiaSharp/Adapters/SkiaSharpAdapter.cs
@@ -75,7 +75,7 @@ namespace TheArtOfDev.HtmlRenderer.SkiaSharp.Adapters
 
         protected override RPen CreatePen(RColor color)
         {
-            return new PenAdapter(new SKPaint { Color = Utils.Convert(color) });
+            return new PenAdapter(new SKPaint { Color = Utils.Convert(color), IsStroke = true });
         }
 
         protected override RBrush CreateSolidBrush(RColor color)

--- a/Source/HtmlRenderer/Core/Dom/CssBox.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssBox.cs
@@ -1346,7 +1346,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                     RGraphicsPath roundrect = null;
                     if (IsRounded)
                     {
-                        roundrect = RenderUtils.GetRoundRect(g, rect, ActualCornerNw, ActualCornerNe, ActualCornerSe, ActualCornerSw);
+                        roundrect = RenderUtils.GetRoundRect(g, rect, ActualBorderRadiusTopLeft, ActualBorderRadiusTopRight, ActualBorderRadiusBottomRight, ActualBorderRadiusBottomLeft);
                     }
 
                     Object prevMode = null;

--- a/Source/HtmlRenderer/Core/Dom/CssBoxProperties.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssBoxProperties.cs
@@ -54,11 +54,11 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
         private string _bottom;
         private string _color = "black";
         private string _content = "normal";
-        private string _cornerNwRadius = "0";
-        private string _cornerNeRadius = "0";
-        private string _cornerSeRadius = "0";
-        private string _cornerSwRadius = "0";
-        private string _cornerRadius = "0";
+        private string _borderTopLeftRadius = "0";
+        private string _borderTopRightRadius = "0";
+        private string _borderBottomRightRadius = "0";
+        private string _borderBottomLeftRadius = "0";
+        private string _borderRadius = "0";
         private string _emptyCells = "show";
         private string _direction = "ltr";
         private string _display = "inline";
@@ -116,10 +116,10 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
         /// </summary>
         private RSize _size;
 
-        private double _actualCornerNw = double.NaN;
-        private double _actualCornerNe = double.NaN;
-        private double _actualCornerSw = double.NaN;
-        private double _actualCornerSe = double.NaN;
+        private double _actualBorderRadiusTopLeft = double.NaN;
+        private double _actualBorderRadiusTopRight = double.NaN;
+        private double _actualBorderRadiusBottomLeft = double.NaN;
+        private double _actualBorderRadiusBottomRight = double.NaN;
         private RColor _actualColor = RColor.Empty;
         private double _actualBackgroundGradientAngle = double.NaN;
         private double _actualHeight = double.NaN;
@@ -276,66 +276,71 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
             set { _borderCollapse = value; }
         }
 
-        public string CornerRadius
+        public string BorderRadius
         {
-            get { return _cornerRadius; }
+            get { return _borderRadius; }
             set
             {
                 MatchCollection r = RegexParserUtils.Match(RegexParserUtils.CssLength, value);
 
                 switch (r.Count)
                 {
-                    case 1:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[0].Value;
-                        CornerSeRadius = r[0].Value;
-                        CornerSwRadius = r[0].Value;
+					// Radius is set for all 4 sides
+					case 1:
+                        BorderTopRightRadius = r[0].Value;
+                        BorderTopLeftRadius = r[0].Value;
+                        BorderBottomRightRadius = r[0].Value;
+                        BorderBottomLeftRadius = r[0].Value;
                         break;
-                    case 2:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[0].Value;
-                        CornerSeRadius = r[1].Value;
-                        CornerSwRadius = r[1].Value;
+					// top-left-and-bottom-right | top-right-and-bottom-left
+					case 2:
+						BorderTopLeftRadius = r[0].Value;
+                        BorderBottomRightRadius = r[0].Value;
+                        BorderTopRightRadius = r[1].Value;
+                        BorderBottomLeftRadius = r[1].Value;
                         break;
-                    case 3:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[1].Value;
-                        CornerSeRadius = r[2].Value;
+					// top-left | top-right-and-bottom-left | bottom-right
+					case 3:
+						BorderTopLeftRadius = r[0].Value;
+                        BorderTopRightRadius = r[1].Value;
+						BorderBottomLeftRadius = r[1].Value;
+                        BorderBottomRightRadius = r[2].Value;
                         break;
-                    case 4:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[1].Value;
-                        CornerSeRadius = r[2].Value;
-                        CornerSwRadius = r[3].Value;
+					// top-left | top-right | bottom-right | bottom-left 
+					case 4:
+                        BorderTopLeftRadius = r[0].Value;
+                        BorderTopRightRadius = r[1].Value;
+                        BorderBottomRightRadius = r[2].Value;
+                        BorderBottomLeftRadius = r[3].Value;
                         break;
                 }
 
-                _cornerRadius = value;
+                _borderRadius = value;
             }
         }
 
-        public string CornerNwRadius
+        public string BorderTopLeftRadius
         {
-            get { return _cornerNwRadius; }
-            set { _cornerNwRadius = value; }
+            get { return _borderTopLeftRadius; }
+            set { _borderTopLeftRadius = value; }
         }
 
-        public string CornerNeRadius
+        public string BorderTopRightRadius
         {
-            get { return _cornerNeRadius; }
-            set { _cornerNeRadius = value; }
+            get { return _borderTopRightRadius; }
+            set { _borderTopRightRadius = value; }
         }
 
-        public string CornerSeRadius
+        public string BorderBottomRightRadius
         {
-            get { return _cornerSeRadius; }
-            set { _cornerSeRadius = value; }
+            get { return _borderBottomRightRadius; }
+            set { _borderBottomRightRadius = value; }
         }
 
-        public string CornerSwRadius
+        public string BorderBottomLeftRadius
         {
-            get { return _cornerSwRadius; }
-            set { _cornerSwRadius = value; }
+            get { return _borderBottomLeftRadius; }
+            set { _borderBottomLeftRadius = value; }
         }
 
         public string MarginBottom
@@ -1125,62 +1130,62 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
         }
 
         /// <summary>
-        /// Gets the actual length of the north west corner
+        /// Gets the actual length of the top left border
         /// </summary>
-        public double ActualCornerNw
+        public double ActualBorderRadiusTopLeft
         {
             get
             {
-                if (double.IsNaN(_actualCornerNw))
+                if (double.IsNaN(_actualBorderRadiusTopLeft))
                 {
-                    _actualCornerNw = CssValueParser.ParseLength(CornerNwRadius, 0, this);
+                    _actualBorderRadiusTopLeft = CssValueParser.ParseLength(BorderTopLeftRadius, 0, this);
                 }
-                return _actualCornerNw;
+                return _actualBorderRadiusTopLeft;
             }
         }
 
         /// <summary>
-        /// Gets the actual length of the north east corner
+        /// Gets the actual length of the top right border
         /// </summary>
-        public double ActualCornerNe
+        public double ActualBorderRadiusTopRight
         {
             get
             {
-                if (double.IsNaN(_actualCornerNe))
+                if (double.IsNaN(_actualBorderRadiusTopRight))
                 {
-                    _actualCornerNe = CssValueParser.ParseLength(CornerNeRadius, 0, this);
+                    _actualBorderRadiusTopRight = CssValueParser.ParseLength(BorderTopRightRadius, 0, this);
                 }
-                return _actualCornerNe;
+                return _actualBorderRadiusTopRight;
             }
         }
 
         /// <summary>
-        /// Gets the actual length of the south east corner
+        /// Gets the actual length of the bottom right border
         /// </summary>
-        public double ActualCornerSe
+        public double ActualBorderRadiusBottomRight
         {
             get
             {
-                if (double.IsNaN(_actualCornerSe))
+                if (double.IsNaN(_actualBorderRadiusBottomRight))
                 {
-                    _actualCornerSe = CssValueParser.ParseLength(CornerSeRadius, 0, this);
+                    _actualBorderRadiusBottomRight = CssValueParser.ParseLength(BorderBottomRightRadius, 0, this);
                 }
-                return _actualCornerSe;
+                return _actualBorderRadiusBottomRight;
             }
         }
 
         /// <summary>
-        /// Gets the actual length of the south west corner
+        /// Gets the actual length of the bottom left border
         /// </summary>
-        public double ActualCornerSw
+        public double ActualBorderRadiusBottomLeft
         {
             get
             {
-                if (double.IsNaN(_actualCornerSw))
+                if (double.IsNaN(_actualBorderRadiusBottomLeft))
                 {
-                    _actualCornerSw = CssValueParser.ParseLength(CornerSwRadius, 0, this);
+                    _actualBorderRadiusBottomLeft = CssValueParser.ParseLength(BorderBottomLeftRadius, 0, this);
                 }
-                return _actualCornerSw;
+                return _actualBorderRadiusBottomLeft;
             }
         }
 
@@ -1189,7 +1194,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
         /// </summary>
         public bool IsRounded
         {
-            get { return ActualCornerNe > 0f || ActualCornerNw > 0f || ActualCornerSe > 0f || ActualCornerSw > 0f; }
+            get { return ActualBorderRadiusTopRight > 0f || ActualBorderRadiusTopLeft > 0f || ActualBorderRadiusBottomRight > 0f || ActualBorderRadiusBottomLeft > 0f; }
         }
 
         /// <summary>
@@ -1554,11 +1559,11 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                     _borderBottomStyle = p._borderBottomStyle;
                     _borderLeftStyle = p._borderLeftStyle;
                     _bottom = p._bottom;
-                    _cornerNwRadius = p._cornerNwRadius;
-                    _cornerNeRadius = p._cornerNeRadius;
-                    _cornerSeRadius = p._cornerSeRadius;
-                    _cornerSwRadius = p._cornerSwRadius;
-                    _cornerRadius = p._cornerRadius;
+                    _borderTopLeftRadius = p._borderTopLeftRadius;
+                    _borderTopRightRadius = p._borderTopRightRadius;
+                    _borderBottomRightRadius = p._borderBottomRightRadius;
+                    _borderBottomLeftRadius = p._borderBottomLeftRadius;
+                    _borderRadius = p._borderRadius;
                     _display = p._display;
                     _float = p._float;
                     _height = p._height;

--- a/Source/HtmlRenderer/Core/Handlers/BordersDrawHandler.cs
+++ b/Source/HtmlRenderer/Core/Handlers/BordersDrawHandler.cs
@@ -206,69 +206,69 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             switch (border)
             {
                 case Border.Top:
-                    if (b.ActualCornerNw > 0 || b.ActualCornerNe > 0)
+                    if (b.ActualBorderRadiusTopLeft > 0 || b.ActualBorderRadiusTopRight > 0)
                     {
                         path = g.GetGraphicsPath();
-                        path.Start(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNw);
+                        path.Start(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualBorderRadiusTopLeft);
 
-                        if (b.ActualCornerNw > 0)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualCornerNw, r.Top + b.ActualBorderTopWidth / 2, b.ActualCornerNw, RGraphicsPath.Corner.TopLeft);
+                        if (b.ActualBorderRadiusTopLeft > 0)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualBorderRadiusTopLeft, r.Top + b.ActualBorderTopWidth / 2, b.ActualBorderRadiusTopLeft, RGraphicsPath.Corner.TopLeft);
 
-                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualCornerNe, r.Top + b.ActualBorderTopWidth / 2);
+                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualBorderRadiusTopRight, r.Top + b.ActualBorderTopWidth / 2);
 
-                        if (b.ActualCornerNe > 0)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNe, b.ActualCornerNe, RGraphicsPath.Corner.TopRight);
+                        if (b.ActualBorderRadiusTopRight > 0)
+                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualBorderRadiusTopRight, b.ActualBorderRadiusTopRight, RGraphicsPath.Corner.TopRight);
                     }
                     break;
                 case Border.Bottom:
-                    if (b.ActualCornerSw > 0 || b.ActualCornerSe > 0)
+                    if (b.ActualBorderRadiusBottomLeft > 0 || b.ActualBorderRadiusBottomRight > 0)
                     {
                         path = g.GetGraphicsPath();
-                        path.Start(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSe);
+                        path.Start(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualBorderRadiusBottomRight);
 
-                        if (b.ActualCornerSe > 0)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualCornerSe, r.Bottom - b.ActualBorderBottomWidth / 2, b.ActualCornerSe, RGraphicsPath.Corner.BottomRight);
+                        if (b.ActualBorderRadiusBottomRight > 0)
+                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualBorderRadiusBottomRight, r.Bottom - b.ActualBorderBottomWidth / 2, b.ActualBorderRadiusBottomRight, RGraphicsPath.Corner.BottomRight);
 
-                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualCornerSw, r.Bottom - b.ActualBorderBottomWidth / 2);
+                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualBorderRadiusBottomLeft, r.Bottom - b.ActualBorderBottomWidth / 2);
 
-                        if (b.ActualCornerSw > 0)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSw, b.ActualCornerSw, RGraphicsPath.Corner.BottomLeft);
+                        if (b.ActualBorderRadiusBottomLeft > 0)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualBorderRadiusBottomLeft, b.ActualBorderRadiusBottomLeft, RGraphicsPath.Corner.BottomLeft);
                     }
                     break;
                 case Border.Right:
-                    if (b.ActualCornerNe > 0 || b.ActualCornerSe > 0)
+                    if (b.ActualBorderRadiusTopRight > 0 || b.ActualBorderRadiusBottomRight > 0)
                     {
                         path = g.GetGraphicsPath();
 
                         bool noTop = b.BorderTopStyle == CssConstants.None || b.BorderTopStyle == CssConstants.Hidden;
                         bool noBottom = b.BorderBottomStyle == CssConstants.None || b.BorderBottomStyle == CssConstants.Hidden;
-                        path.Start(r.Right - b.ActualBorderRightWidth / 2 - (noTop ? b.ActualCornerNe : 0), r.Top + b.ActualBorderTopWidth / 2 + (noTop ? 0 : b.ActualCornerNe));
+                        path.Start(r.Right - b.ActualBorderRightWidth / 2 - (noTop ? b.ActualBorderRadiusTopRight : 0), r.Top + b.ActualBorderTopWidth / 2 + (noTop ? 0 : b.ActualBorderRadiusTopRight));
 
-                        if (b.ActualCornerNe > 0 && noTop)
-                            path.ArcTo(r.Right - b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNe, b.ActualCornerNe, RGraphicsPath.Corner.TopRight);
+                        if (b.ActualBorderRadiusTopRight > 0 && noTop)
+                            path.ArcTo(r.Right - b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualBorderRadiusTopRight, b.ActualBorderRadiusTopRight, RGraphicsPath.Corner.TopRight);
 
-                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSe);
+                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualBorderRadiusBottomRight);
 
-                        if (b.ActualCornerSe > 0 && noBottom)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualCornerSe, r.Bottom - b.ActualBorderBottomWidth / 2, b.ActualCornerSe, RGraphicsPath.Corner.BottomRight);
+                        if (b.ActualBorderRadiusBottomRight > 0 && noBottom)
+                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualBorderRadiusBottomRight, r.Bottom - b.ActualBorderBottomWidth / 2, b.ActualBorderRadiusBottomRight, RGraphicsPath.Corner.BottomRight);
                     }
                     break;
                 case Border.Left:
-                    if (b.ActualCornerNw > 0 || b.ActualCornerSw > 0)
+                    if (b.ActualBorderRadiusTopLeft > 0 || b.ActualBorderRadiusBottomLeft > 0)
                     {
                         path = g.GetGraphicsPath();
 
                         bool noTop = b.BorderTopStyle == CssConstants.None || b.BorderTopStyle == CssConstants.Hidden;
                         bool noBottom = b.BorderBottomStyle == CssConstants.None || b.BorderBottomStyle == CssConstants.Hidden;
-                        path.Start(r.Left + b.ActualBorderLeftWidth / 2 + (noBottom ? b.ActualCornerSw : 0), r.Bottom - b.ActualBorderBottomWidth / 2 - (noBottom ? 0 : b.ActualCornerSw));
+                        path.Start(r.Left + b.ActualBorderLeftWidth / 2 + (noBottom ? b.ActualBorderRadiusBottomLeft : 0), r.Bottom - b.ActualBorderBottomWidth / 2 - (noBottom ? 0 : b.ActualBorderRadiusBottomLeft));
 
-                        if (b.ActualCornerSw > 0 && noBottom)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSw, b.ActualCornerSw, RGraphicsPath.Corner.BottomLeft);
+                        if (b.ActualBorderRadiusBottomLeft > 0 && noBottom)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualBorderRadiusBottomLeft, b.ActualBorderRadiusBottomLeft, RGraphicsPath.Corner.BottomLeft);
 
-                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNw);
+                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualBorderRadiusTopLeft);
 
-                        if (b.ActualCornerNw > 0 && noTop)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualCornerNw, r.Top + b.ActualBorderTopWidth / 2, b.ActualCornerNw, RGraphicsPath.Corner.TopLeft);
+                        if (b.ActualBorderRadiusTopLeft > 0 && noTop)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualBorderRadiusTopLeft, r.Top + b.ActualBorderTopWidth / 2, b.ActualBorderRadiusTopLeft, RGraphicsPath.Corner.TopLeft);
                     }
                     break;
             }

--- a/Source/HtmlRenderer/Core/Utils/CssUtils.cs
+++ b/Source/HtmlRenderer/Core/Utils/CssUtils.cs
@@ -96,16 +96,16 @@ namespace TheArtOfDev.HtmlRenderer.Core.Utils
                     return cssBox.BorderSpacing;
                 case "border-collapse":
                     return cssBox.BorderCollapse;
-                case "corner-radius":
-                    return cssBox.CornerRadius;
-                case "corner-nw-radius":
-                    return cssBox.CornerNwRadius;
-                case "corner-ne-radius":
-                    return cssBox.CornerNeRadius;
-                case "corner-se-radius":
-                    return cssBox.CornerSeRadius;
-                case "corner-sw-radius":
-                    return cssBox.CornerSwRadius;
+                case "border-radius":
+                    return cssBox.BorderRadius;
+                case "border-top-left-radius":
+                    return cssBox.BorderTopLeftRadius;
+                case "border-top-right-radius":
+                    return cssBox.BorderTopRightRadius;
+                case "border-bottom-right-radius":
+                    return cssBox.BorderBottomRightRadius;
+                case "border-bottom-left-radius":
+                    return cssBox.BorderBottomLeftRadius;
                 case "margin-bottom":
                     return cssBox.MarginBottom;
                 case "margin-left":
@@ -259,20 +259,20 @@ namespace TheArtOfDev.HtmlRenderer.Core.Utils
                 case "border-collapse":
                     cssBox.BorderCollapse = value;
                     break;
-                case "corner-radius":
-                    cssBox.CornerRadius = value;
+                case "border-radius":
+                    cssBox.BorderRadius = value;
                     break;
-                case "corner-nw-radius":
-                    cssBox.CornerNwRadius = value;
+                case "border-top-left-radius":
+                    cssBox.BorderTopLeftRadius = value;
                     break;
-                case "corner-ne-radius":
-                    cssBox.CornerNeRadius = value;
+                case "border-top-right-radius":
+                    cssBox.BorderTopRightRadius = value;
                     break;
-                case "corner-se-radius":
-                    cssBox.CornerSeRadius = value;
+                case "border-bottom-right-radius":
+                    cssBox.BorderBottomRightRadius = value;
                     break;
-                case "corner-sw-radius":
-                    cssBox.CornerSwRadius = value;
+                case "border-bottom-left-radius":
+                    cssBox.BorderBottomLeftRadius = value;
                     break;
                 case "margin-bottom":
                     cssBox.MarginBottom = value;

--- a/Source/HtmlRenderer/Core/Utils/RenderUtils.cs
+++ b/Source/HtmlRenderer/Core/Utils/RenderUtils.cs
@@ -96,43 +96,43 @@ namespace TheArtOfDev.HtmlRenderer.Core.Utils
 
         /// <summary>
         /// Creates a rounded rectangle using the specified corner radius<br/>
-        /// NW-----NE
+        /// TL------TR
         ///  |       |
         ///  |       |
-        /// SW-----SE
+        /// BL------BR
         /// </summary>
         /// <param name="g">the device to draw into</param>
         /// <param name="rect">Rectangle to round</param>
-        /// <param name="nwRadius">Radius of the north east corner</param>
-        /// <param name="neRadius">Radius of the north west corner</param>
-        /// <param name="seRadius">Radius of the south east corner</param>
-        /// <param name="swRadius">Radius of the south west corner</param>
+        /// <param name="topLeftRadius">Radius of the top left corner</param>
+        /// <param name="topRightRadius">Radius of the top right corner</param>
+        /// <param name="bottomRightRadius">Radius of the bottom right corner</param>
+        /// <param name="bottomLeftRadius">Radius of the bottom left corner</param>
         /// <returns>GraphicsPath with the lines of the rounded rectangle ready to be painted</returns>
-        public static RGraphicsPath GetRoundRect(RGraphics g, RRect rect, double nwRadius, double neRadius, double seRadius, double swRadius)
+        public static RGraphicsPath GetRoundRect(RGraphics g, RRect rect, double topLeftRadius, double topRightRadius, double bottomRightRadius, double bottomLeftRadius)
         {
             var path = g.GetGraphicsPath();
 
-            path.Start(rect.Left + nwRadius, rect.Top);
+            path.Start(rect.Left + topLeftRadius, rect.Top);
 
-            path.LineTo(rect.Right - neRadius, rect.Y);
+            path.LineTo(rect.Right - topRightRadius, rect.Y);
 
-            if (neRadius > 0f)
-                path.ArcTo(rect.Right, rect.Top + neRadius, neRadius, RGraphicsPath.Corner.TopRight);
+            if (topRightRadius > 0f)
+                path.ArcTo(rect.Right, rect.Top + topRightRadius, topRightRadius, RGraphicsPath.Corner.TopRight);
 
-            path.LineTo(rect.Right, rect.Bottom - seRadius);
+            path.LineTo(rect.Right, rect.Bottom - bottomRightRadius);
 
-            if (seRadius > 0f)
-                path.ArcTo(rect.Right - seRadius, rect.Bottom, seRadius, RGraphicsPath.Corner.BottomRight);
+            if (bottomRightRadius > 0f)
+                path.ArcTo(rect.Right - bottomRightRadius, rect.Bottom, bottomRightRadius, RGraphicsPath.Corner.BottomRight);
 
-            path.LineTo(rect.Left + swRadius, rect.Bottom);
+            path.LineTo(rect.Left + bottomLeftRadius, rect.Bottom);
 
-            if (swRadius > 0f)
-                path.ArcTo(rect.Left, rect.Bottom - swRadius, swRadius, RGraphicsPath.Corner.BottomLeft);
+            if (bottomLeftRadius > 0f)
+                path.ArcTo(rect.Left, rect.Bottom - bottomLeftRadius, bottomLeftRadius, RGraphicsPath.Corner.BottomLeft);
 
-            path.LineTo(rect.Left, rect.Top + nwRadius);
+            path.LineTo(rect.Left, rect.Top + topLeftRadius);
 
-            if (nwRadius > 0f)
-                path.ArcTo(rect.Left + nwRadius, rect.Top, nwRadius, RGraphicsPath.Corner.TopLeft);
+            if (topLeftRadius > 0f)
+                path.ArcTo(rect.Left + topLeftRadius, rect.Top, topLeftRadius, RGraphicsPath.Corner.TopLeft);
 
             return path;
         }


### PR DESCRIPTION
In this PR:
- Rename corner-radius to border-radius
- Fix implementation of shorthand border-radius (i.e. for `border-radius: 10px 20px;`, the first value refers to the top left & bottom right corners, not the top two corners.)
- Fix call to SKPath.ArcTo
- Fix Skia PenAdapter to use stroke